### PR TITLE
Flatpak: Update libaio to 0.3.113 and use HTTPS

### DIFF
--- a/build-aux/com.github.alecaddd.sequeler.json
+++ b/build-aux/com.github.alecaddd.sequeler.json
@@ -109,8 +109,8 @@
           ],
           "sources": [{
             "type": "archive",
-            "url": "http://ftp.de.debian.org/debian/pool/main/liba/libaio/libaio_0.3.110.orig.tar.gz",
-            "sha256": "e019028e631725729376250e32b473012f7cb68e1f7275bfc1bbcdd0f8745f7e"
+            "url": "https://ftp.debian.org/debian/pool/main/liba/libaio/libaio_0.3.113.orig.tar.gz",
+            "sha256": "2c44d1c5fd0d43752287c9ae1eb9c023f04ef848ea8d4aafa46e9aedb678200b"
           }]
         },
         {

--- a/com.github.alecaddd.sequeler.yml
+++ b/com.github.alecaddd.sequeler.yml
@@ -105,8 +105,8 @@
           ],
           "sources": [{
             "type": "archive",
-            "url": "http://ftp.de.debian.org/debian/pool/main/liba/libaio/libaio_0.3.110.orig.tar.gz",
-            "sha256": "e019028e631725729376250e32b473012f7cb68e1f7275bfc1bbcdd0f8745f7e"
+            "url": "http://ftp.de.debian.org/debian/pool/main/liba/libaio/libaio_0.3.113.orig.tar.gz",
+            "sha256": "2c44d1c5fd0d43752287c9ae1eb9c023f04ef848ea8d4aafa46e9aedb678200b"
           }]
         },
         {

--- a/com.github.alecaddd.sequeler.yml
+++ b/com.github.alecaddd.sequeler.yml
@@ -105,7 +105,7 @@
           ],
           "sources": [{
             "type": "archive",
-            "url": "http://ftp.de.debian.org/debian/pool/main/liba/libaio/libaio_0.3.113.orig.tar.gz",
+            "url": "https://ftp.debian.org/debian/pool/main/liba/libaio/libaio_0.3.113.orig.tar.gz",
             "sha256": "2c44d1c5fd0d43752287c9ae1eb9c023f04ef848ea8d4aafa46e9aedb678200b"
           }]
         },


### PR DESCRIPTION
This fixes the Flatpak CI is failing.