### PR TITLE
l10n: Setup locales correctly

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -33,6 +33,11 @@ public class Sequeler.Application : Gtk.Application {
         application_id = Constants.PROJECT_NAME;
         flags |= ApplicationFlags.HANDLES_OPEN;
 
+        GLib.Intl.setlocale (LocaleCategory.ALL, "");
+        GLib.Intl.bindtextdomain (Constants.GETTEXT_PACKAGE, Constants.LOCALEDIR);
+        GLib.Intl.bind_textdomain_codeset (Constants.GETTEXT_PACKAGE, "UTF-8");
+        GLib.Intl.textdomain (Constants.GETTEXT_PACKAGE);
+
         schema = new Secret.Schema (Constants.PROJECT_NAME, Secret.SchemaFlags.NONE,
                                  "id", Secret.SchemaAttributeType.INTEGER,
                                  "schema", Secret.SchemaAttributeType.STRING);

--- a/src/config.vala.in
+++ b/src/config.vala.in
@@ -1,5 +1,6 @@
 namespace Constants {
 	public const string PROJECT_NAME = "@PROJECT_NAME@";
 	public const string GETTEXT_PACKAGE = "@GETTEXT_PACKAGE@";
+	public const string LOCALEDIR = "@LOCALEDIR@";
 	public const string VERSION = "@VERSION@";
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,7 @@
 conf_data = configuration_data()
 conf_data.set('PROJECT_NAME', application_id)
 conf_data.set('GETTEXT_PACKAGE', meson.project_name())
+conf_data.set('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
 conf_data.set('VERSION', meson.project_version())
 
 config_header = configure_file(


### PR DESCRIPTION
This fixes that the translations are not loaded in Flatpak.

## Before
![スクリーンショット 2024-10-05 02 44 54](https://github.com/user-attachments/assets/dfc74cf1-105b-42b3-ba3d-82501538edd9)

## After
![スクリーンショット 2024-10-05 02 46 07](https://github.com/user-attachments/assets/c0c0ff1a-6382-411a-9b2e-7dc5348fa32c)
